### PR TITLE
Fix doctests and add CodeBlock node

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,3 +21,6 @@ API
 
 .. autoclass:: rst.Table
    :members:
+
+.. autoclass:: rst.CodeBlock
+   :members:

--- a/rst/rst.py
+++ b/rst/rst.py
@@ -117,6 +117,13 @@ class Document(object):
                     print_table(out, child.header)
                 for ch in child.children:
                     print_table(out, ch)
+                out.write(u('\n'))
+            elif isinstance(child, CodeBlock):
+                out.write(u('.. code-block:: %s\n') % child.lang)
+                if child.linenos:
+                    out.write(u('    :linenos:\n\n'))
+                indented = "\n".join("    {}".format(l) for l in child.code.split("\n"))
+                out.write(u("{}\n".format(indented)))
 
         return out.getvalue()
 
@@ -300,6 +307,38 @@ class Table(Node):
         """
         self.children.append([txt for txt in row])
 
+
+class CodeBlock(Node):
+    r"""
+    Represents a Code Block.
+
+    .. doctest::
+
+        >>> import rst
+        >>> doc = rst.Document('Title of the report')
+        >>> code = rst.CodeBlock("import sys\nsys.stdout.write('Working')", lang="python", linenos=True)
+        >>> doc.add_child(code)
+        True
+        >>> print(doc.get_rst())
+        ===================
+        Title of the report
+        ===================
+        <BLANKLINE>
+        .. code-block:: python
+            :linenos:
+        <BLANKLINE>
+            import sys
+            sys.stdout.write('Working')
+        <BLANKLINE>
+
+    """
+    def __init__(self, code, lang='', linenos=False):
+        Node.__init__(self)
+        self.code = code
+        self.lang = lang
+        self.linenos = linenos
+
+
 if __name__ == '__main__':
     doc = Document('Title of the report')
     para = Paragraph('Just another paragraph. We need few more of these.')
@@ -325,4 +364,7 @@ if __name__ == '__main__':
     tbl.add_child(('Nicubunu', 'Fedora'))
     doc.add_child(tbl)
 
-    doc.get_rst()
+    code = CodeBlock("import sys\nsys.stdout.write('Working')", lang="python", linenos=True)
+    doc.add_child(code)
+
+    print(doc.get_rst())

--- a/rst/rst.py
+++ b/rst/rst.py
@@ -18,13 +18,14 @@
 #OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #SOFTWARE.
 
+from __future__ import print_function
+
 import codecs
 try:
     import StringIO
 except:
     import io
 from six import u
-
 
 def create_section(text, depth):
     marks = u('=-+#')
@@ -51,12 +52,12 @@ class Document(object):
 
         >>> import rst
         >>> doc = rst.Document('Title of the report')
-        >>> print doc.get_rst()
+        >>> print(doc.get_rst())
         ===================
         Title of the report
         ===================
-
-
+        <BLANKLINE>
+        <BLANKLINE>
 
     """
     def __init__(self, title):
@@ -153,12 +154,14 @@ class Paragraph(Node):
         >>> para = rst.Paragraph('This is a paragraph. A long one.')
         >>> doc.add_child(para)
         True
-        >>> print doc.get_rst()
+        >>> print(doc.get_rst())
         ===================
         Title of the report
         ===================
-
+        <BLANKLINE>
         This is a paragraph. A long one.
+        <BLANKLINE>
+        <BLANKLINE>
     """
     def __init__(self, text=''):
         Node.__init__(self)
@@ -191,13 +194,16 @@ class Bulletlist(Node):
         >>> blt.add_item('Debian')
         >>> doc.add_child(blt)
         True
-        >>> print doc.get_rst()
+        >>> print(doc.get_rst())
         ===================
         Title of the report
         ===================
-
+        <BLANKLINE>
             * Fedora
             * Debian
+        <BLANKLINE>
+        <BLANKLINE>
+
     """
     def __init__(self):
         Node.__init__(self)
@@ -224,13 +230,15 @@ class Orderedlist(Node):
         >>> blt.add_item('Debian')
         >>> doc.add_child(blt)
         True
-        >>> print doc.get_rst()
+        >>> print(doc.get_rst())
         ===================
         Title of the report
         ===================
-
+        <BLANKLINE>
             1. Fedora
             2. Debian
+        <BLANKLINE>
+        <BLANKLINE>
 
     """
     def __init__(self):
@@ -259,14 +267,14 @@ class Table(Node):
         >>> tbl.add_item(('Nicubunu', 'Fedora'))
         >>> doc.add_child(tbl)
         True
-        >>> print doc.get_rst()
+        >>> print(doc.get_rst())
         ===================
         Title of the report
         ===================
-
+        <BLANKLINE>
         .. list-table:: My friends
             :header-rows: 1
-
+        <BLANKLINE>
             * -  Name
               -  Major Project
             * -  Ramki
@@ -275,7 +283,7 @@ class Table(Node):
               -  Kde
             * -  Nicubunu
               -  Fedora
-
+        <BLANKLINE>
 
     """
     def __init__(self, title='', header=None, width=None):

--- a/tests.py
+++ b/tests.py
@@ -68,7 +68,7 @@ Sample document
         self.assertEqual(text, actual_text)
 
     def test_codeblock(self):
-        "test the OrderedList in the document"
+        "test the CodeBlock in the document"
         doc = rst.Document(u("T"))
         code = rst.CodeBlock("import sys", lang="python", linenos=True)
         doc.add_child(code)

--- a/tests.py
+++ b/tests.py
@@ -67,6 +67,15 @@ Sample document
         actual_text = u('=\nT\n=\n\n    1. Fedora\n    2. Debian\n\n')
         self.assertEqual(text, actual_text)
 
+    def test_codeblock(self):
+        "test the OrderedList in the document"
+        doc = rst.Document(u("T"))
+        code = rst.CodeBlock("import sys", lang="python", linenos=True)
+        doc.add_child(code)
+        text = doc.get_rst()
+        actual_text = u('=\nT\n=\n\n.. code-block:: python\n    :linenos:\n\n    import sys\n')
+        self.assertEqual(text, actual_text)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR:

- adds a new CodeBlock object
- adds CodeBlock to docs
- fixes doctests (adds `<BLANKLINE>`s and `from __future__ import print_statement`)
